### PR TITLE
Fixing a test, that [System.IO.Path]::GetTempPath() returns a long pa…

### DIFF
--- a/Tests/Utilities.Tests.ps1
+++ b/Tests/Utilities.Tests.ps1
@@ -9,7 +9,7 @@ Describe 'Validate various support functions for testing' {
             $tempPath = Get-TempPath
 
             if ($IsWindows) {
-                $tempPath.IndexOf($Env:TEMP) | Should -Be 0
+                $tempPath.IndexOf((Get-Item -LiteralPath $Env:TEMP).FullName) | Should -Be 0
             } elseif ($IsLinux) {
                 $tempPath.IndexOf('/tmp') | Should -Be 0
             }


### PR DESCRIPTION
This fixes a breaking test on Windows environment, given when the username exceeds 11 chars long, `[System.IO.Path]::GetTempPath()` returns the long path, but `$Env:TEMP` returns a short path.

The fix is to expand `$Env:TEMP` to long path and use that for comparison.