### PR TITLE
Reduce travis to only build on pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ language: csharp
 dotnet: 2.1
 mono: none
 
+if: |
+  repo != 3shapeAS/dockerbuild-pwsh OR \
+  type = pull_request OR \
+  branch = master
+
 services:
   - docker
 


### PR DESCRIPTION
Free for Open Source
We love Open Source and offer a free plan for your projects. You will receive unlimited builds and **3 concurrent jobs** for free, along with all the other features you've come to love from Travis CI.

https://travis-ci.com/plans

With 3 current jobs limit I want to reduce the amount of building on branches.

Also better to fork the repo to "unlock" the limit by enabling travis on your repo 🙈 