### PR TITLE
docker pull

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -96,9 +96,9 @@ Task Clean -depends Init -requiredVariables PublishDir {
 }
 
 Task Init -requiredVariables PublishDir {
-   if (!(Test-Path $PublishDir)) {
-       $null = New-Item $PublishDir -ItemType Directory
-   }
+    if (!(Test-Path $PublishDir)) {
+        $null = New-Item $PublishDir -ItemType Directory
+    }
 }
 
 Task ? -description 'Lists the available tasks' {

--- a/Private/Test-DockerDigest.ps1
+++ b/Private/Test-DockerDigest.ps1
@@ -1,0 +1,11 @@
+
+function Test-DockerDigest {
+    param (
+        [Parameter(Mandatory=$true)]
+        [String] $Digest
+    )
+
+    $shaPrefix = 'sha256:'
+    $shaLength = 64
+    return $Digest.StartsWith($shaPrefix) -and $Digest.Length -eq ($shaPrefix.Length + $shaLength)
+}

--- a/Private/Utilities.ps1
+++ b/Private/Utilities.ps1
@@ -34,17 +34,31 @@ url = https://github.com/3shapeAS/dockerbuild-pwsh.git
     $configData | Out-File -FilePath "$dotGitPath/config" -Encoding ascii
 }
 
-function Add-Postfix {
+function Add-RegistryPostfix {
     param (
-        [Parameter(Mandatory=$true)]
-        [String] $Data,
+        [String] $Registry,
         [ValidateNotNullOrEmpty()]
         [String] $Postfix = '/'
     )
 
-    $trimmedData = $Data.Trim()
-    if ( -Not $trimmedData.EndsWith($Postfix) ) {
-            $trimmedData += $Postfix
+    # Do nothing if $Data is empty / writespace
+    if ([String]::IsNullOrWhiteSpace($Registry)) {
+        return ''
     }
-    $trimmedData
+
+    $trimmedRegistry = $Registry.Trim()
+    if ( -Not $trimmedRegistry.EndsWith($Postfix) ) {
+            $trimmedRegistry += $Postfix
+    }
+    $trimmedRegistry
+}
+
+function Test-DockerDigest {
+    param (
+        [Parameter(Mandatory=$true)]
+        [String] $Digest
+    )
+
+    $shaPrefix = 'sha256:'
+    return $Digest.StartsWith($shaPrefix) -and $Digest.Length -eq ($shaPrefix.Length + 64)
 }

--- a/Private/Utilities.ps1
+++ b/Private/Utilities.ps1
@@ -52,13 +52,3 @@ function Add-RegistryPostfix {
     }
     $trimmedRegistry
 }
-
-function Test-DockerDigest {
-    param (
-        [Parameter(Mandatory=$true)]
-        [String] $Digest
-    )
-
-    $shaPrefix = 'sha256:'
-    return $Digest.StartsWith($shaPrefix) -and $Digest.Length -eq ($shaPrefix.Length + 64)
-}

--- a/Private/Utilities.ps1
+++ b/Private/Utilities.ps1
@@ -34,16 +34,15 @@ url = https://github.com/3shapeAS/dockerbuild-pwsh.git
     $configData | Out-File -FilePath "$dotGitPath/config" -Encoding ascii
 }
 
-function Add-RegistryPostfix {
+function Add-Postfix {
     param (
         [String] $Registry,
         [ValidateNotNullOrEmpty()]
         [String] $Postfix = '/'
     )
 
-    # Do nothing if $Data is empty / writespace
     if ([String]::IsNullOrWhiteSpace($Registry)) {
-        return ''
+        return $Registry
     }
 
     $trimmedRegistry = $Registry.Trim()

--- a/Public/Invoke-DockerPull.ps1
+++ b/Public/Invoke-DockerPull.ps1
@@ -32,7 +32,7 @@ function Invoke-DockerPull {
     if (-Not [String]::IsNullOrEmpty($Digest)) {
         $validDigest = Test-DockerDigest -Digest $Digest
         if (-Not $validDigest) {
-            throw "Invalid digest provided."
+            throw "Invalid digest provided, digest: ${Digest}"
         }
         $imageToPull = "${registryPostfixed}${Image}@${Digest}"
     }

--- a/Public/Invoke-DockerPull.ps1
+++ b/Public/Invoke-DockerPull.ps1
@@ -1,0 +1,23 @@
+#Requires -PSEdition Core -Version 6
+
+function Invoke-DockerPull {
+    [CmdletBinding()]
+    param (
+        [Parameter(mandatory=$true)]
+        [String]
+        $Image,
+        [ValidateNotNullOrEmpty()]
+        [String]
+        $Tag = 'latest',
+        [ValidateNotNullOrEmpty()]
+        [String]
+        $ID = ''
+    )
+
+    # It is possible to pull by digest / sha, ID. ID supersedes image:tag.
+    #   So if ID is present, use ID. If not, pull image:tag
+    if ( [string]::IsNullOrEmpty($ID) ) {
+        $ID = "${Image}:${Tag}"
+    }
+    Invoke-Command "docker pull ${ID}"
+}

--- a/Public/Invoke-DockerPull.ps1
+++ b/Public/Invoke-DockerPull.ps1
@@ -4,21 +4,29 @@ function Invoke-DockerPull {
         [ValidateNotNullOrEmpty()]
         [String]
         $Registry,
-        [Parameter(mandatory=$true)]
+
+        # Pull by name, by name + tag, by name + digest
+        [Parameter(mandatory = $true,ParameterSetName = 'WithImageOnly')]
+        [Parameter(mandatory = $true,ParameterSetName = 'WithImageAndDigest')]
+        [Parameter(mandatory = $true,ParameterSetName = 'WithImageAndTag')]
         [String]
         $Image,
+
         [ValidateNotNullOrEmpty()]
+        [Parameter(mandatory = $true,ParameterSetName = 'WithImageAndTag')]
         [String]
         $Tag = 'latest',
+
         [ValidateNotNullOrEmpty()]
+        [Parameter(mandatory = $true,ParameterSetName = 'WithImageAndDigest')]
         [String]
         $Digest = ''
     )
 
-    $RegistryPostfixed = Add-RegistryPostfix -Registry $Registry
+    $registryPostfixed = Add-RegistryPostfix -Registry $Registry
 
     # Pulls by tag by default
-    $ImageToPull = "${RegistryPostfixed}${Image}:${Tag}"
+    $imageToPull = "${registryPostfixed}${Image}:${Tag}"
 
     # Digest overrides tag however
     if (-Not [String]::IsNullOrEmpty($Digest)) {
@@ -26,7 +34,7 @@ function Invoke-DockerPull {
         if (-Not $validDigest) {
             throw "Invalid digest provided."
         }
-        $ImageToPull = "${RegistryPostfixed}${Image}@${Digest}"
+        $imageToPull = "${registryPostfixed}${Image}@${Digest}"
     }
-    Invoke-Command "docker pull ${ImageToPull}"
+    Invoke-Command "docker pull ${imageToPull}"
 }

--- a/Public/Invoke-DockerPull.ps1
+++ b/Public/Invoke-DockerPull.ps1
@@ -23,7 +23,7 @@ function Invoke-DockerPull {
         $Digest = ''
     )
 
-    $registryPostfixed = Add-RegistryPostfix -Registry $Registry
+    $registryPostfixed = Add-Postfix -Registry $Registry
 
     # Pulls by tag by default
     $imageToPull = "${registryPostfixed}${Image}:${Tag}"

--- a/Public/Invoke-DockerTag.ps1
+++ b/Public/Invoke-DockerTag.ps1
@@ -19,18 +19,10 @@ function Invoke-DockerTag {
         $TargetTag = 'latest'
     )
 
-    $SourceRegistryPostfixed = $SourceRegistry
-    $TargetRegistryPostfixed = $TargetRegistry
-
-    # Add postfix /
-    if (-Not ([String]::IsNullOrWhiteSpace($SourceRegistry))) {
-        $SourceRegistryPostfixed = Add-Postfix -Data $SourceRegistry
-    }
-    if (-Not ([String]::IsNullOrWhiteSpace($TargetRegistry))) {
-        $TargetRegistryPostfixed = Add-Postfix -Data $TargetRegistry
-    }
-
+    $SourceRegistryPostfixed = Add-RegistryPostfix -Registry $SourceRegistry
+    $TargetRegistryPostfixed = Add-RegistryPostfix -Registry $TargetRegistry
     $source = "${SourceRegistryPostfixed}${SourceImage}:${SourceTag}"
     $target = "${TargetRegistryPostfixed}${TargetImage}:${TargetTag}"
+
     Invoke-Command "docker tag ${source} ${target}"
 }

--- a/Public/Invoke-DockerTag.ps1
+++ b/Public/Invoke-DockerTag.ps1
@@ -24,8 +24,8 @@ function Invoke-DockerTag {
         $TargetTag = 'latest'
     )
 
-    $SourceRegistryPostfixed = Add-RegistryPostfix -Registry $SourceRegistry
-    $TargetRegistryPostfixed = Add-RegistryPostfix -Registry $TargetRegistry
+    $SourceRegistryPostfixed = Add-Postfix -Registry $SourceRegistry
+    $TargetRegistryPostfixed = Add-Postfix -Registry $TargetRegistry
     $source = "${SourceRegistryPostfixed}${SourceImage}:${SourceTag}"
     $target = "${TargetRegistryPostfixed}${TargetImage}:${TargetTag}"
 

--- a/Public/Invoke-DockerTag.ps1
+++ b/Public/Invoke-DockerTag.ps1
@@ -3,17 +3,22 @@ function Invoke-DockerTag {
     param (
         [String]
         $SourceRegistry = '',
+
         [Parameter(mandatory=$true)]
         [String]
         $SourceImage,
+
         [ValidateNotNullOrEmpty()]
         [String]
         $SourceTag = 'latest',
+
         [String]
         $TargetRegistry = '',
+
         [Parameter(mandatory=$true)]
         [String]
         $TargetImage,
+
         [ValidateNotNullOrEmpty()]
         [String]
         $TargetTag = 'latest'

--- a/Tests/Invoke-DockerPull.Tests.ps1
+++ b/Tests/Invoke-DockerPull.Tests.ps1
@@ -1,0 +1,70 @@
+Import-Module $PSScriptRoot/../Docker.Build.psm1
+Import-Module -Global -Force $PSScriptRoot/MockReg.psm1
+. "$PSScriptRoot\..\Private\Invoke-Command.ps1"
+
+Describe 'Pull docker images' {
+
+    BeforeAll {
+        $script:moduleName = (Get-Item $PSScriptRoot\..\*.psd1)[0].BaseName
+    }
+
+    Context 'Pull docker images' {
+
+        BeforeEach {
+            Initialize-MockReg
+        }
+
+        $code = {
+            Write-Debug $Command
+            StoreMockValue -Key "mock" -Value $Command
+        }
+
+        It 'pulls docker image with image name only' {
+
+            Mock -CommandName "Invoke-Command" $code -Verifiable -ModuleName $script:moduleName
+
+            Invoke-DockerTag -SourceImage 'lalaland' -TargetImage 'lololand'
+            Assert-MockCalled -CommandName "Invoke-Command" -ModuleName $script:moduleName
+
+            $result = GetMockValue -Key "mock"
+            Write-Debug $result
+            $result | Should -BeLikeExactly "docker tag lalaland:latest lololand:latest"
+        }
+
+        It 'pulls docker image with image name with random tag' {
+
+            Mock -CommandName "Invoke-Command" $code -Verifiable -ModuleName $script:moduleName
+
+            Invoke-DockerTag -SourceImage 'lalaland' -SourceTag 'latest' -TargetImage 'lololand' -TargetTag 'latest'
+
+            Assert-MockCalled -CommandName "Invoke-Command" -ModuleName $script:moduleName
+            $result = GetMockValue -Key "mock"
+            Write-Debug $result
+            $result | Should -BeLikeExactly "docker tag lalaland:latest lololand:latest"
+        }
+
+        It 'pulls docker image with ID' {
+
+            Mock -CommandName "Invoke-Command" $code -Verifiable -ModuleName $script:moduleName
+
+            Invoke-DockerTag -SourceImage 'lalaland' -SourceTag 'source' -TargetImage 'lololand'
+
+            Assert-MockCalled -CommandName "Invoke-Command" -ModuleName $script:moduleName
+            $result = GetMockValue -Key "mock"
+            Write-Debug $result
+            $result | Should -BeLikeExactly "docker tag lalaland:source lololand:latest"
+        }
+
+        It 'fails to pull docker image with both image name and ID' {
+
+            Mock -CommandName "Invoke-Command" $code -Verifiable -ModuleName $script:moduleName
+
+            Invoke-DockerTag -SourceImage 'lalaland' -TargetImage 'lololand' -TargetTag 'target'
+
+            Assert-MockCalled -CommandName "Invoke-Command" -ModuleName $script:moduleName
+            $result = GetMockValue -Key "mock"
+            Write-Debug $result
+            $result | Should -BeLikeExactly "docker tag lalaland:latest lololand:target"
+        }
+    }
+}

--- a/Tests/Invoke-DockerPull.Tests.ps1
+++ b/Tests/Invoke-DockerPull.Tests.ps1
@@ -24,7 +24,7 @@ Describe 'Pull docker images' {
 
     Context 'Docker pulls docker images' {
 
-        It 'pulls public docker image with image name only' {
+        It 'pulls public docker image by image name only' {
             # This test will most likely fail IRL because there isn't any latest tag available for this image
             Invoke-DockerPull -Image 'mcr.microsoft.com/windows/servercore'
             $result = GetMockValue -Key "pull"
@@ -32,25 +32,54 @@ Describe 'Pull docker images' {
             $result | Should -BeLikeExactly "docker pull mcr.microsoft.com/windows/servercore:latest"
         }
 
-        It 'pulls public docker image with image name and tag' {
+        It 'pulls public docker image by registry and image name' {
+            # This test will most likely fail IRL because there isn't any latest tag available for this image
+            Invoke-DockerPull -Registry 'mcr.microsoft.com/windows' -Image 'servercore'
+            $result = GetMockValue -Key "pull"
+            Write-Debug $result
+            $result | Should -BeLikeExactly "docker pull mcr.microsoft.com/windows/servercore:latest"
+        }
+
+        It 'pulls public docker image by image name and tag' {
             Invoke-DockerPull -Image 'mcr.microsoft.com/windows/servercore' -Tag 'ltsc2019'
             $result = GetMockValue -Key "pull"
             Write-Debug $result
             $result | Should -BeLikeExactly "docker pull mcr.microsoft.com/windows/servercore:ltsc2019"
         }
 
-        It 'pulls public docker image with image name and digest' {
+        It 'pulls public docker image by image name and digest' {
             Invoke-DockerPull -Image 'mcr.microsoft.com/windows/servercore' -Digest 'sha256:f5c0a8d225a4b7556db2b26753a7f4c4de3b090c1a8852983885b80694ca9840'
             $result = GetMockValue -Key "pull"
             Write-Debug $result
             $result | Should -BeLikeExactly "docker pull mcr.microsoft.com/windows/servercore@sha256:f5c0a8d225a4b7556db2b26753a7f4c4de3b090c1a8852983885b80694ca9840"
         }
 
-        It 'pulls public docker image with image name, tag and digest; digest overrides tag' {
-            Invoke-DockerPull -Image 'mcr.microsoft.com/windows/servercore' -Tag 'ltsc2019' -Digest 'sha256:f5c0a8d225a4b7556db2b26753a7f4c4de3b090c1a8852983885b80694ca9840'
-            $result = GetMockValue -Key "pull"
-            Write-Debug $result
-            $result | Should -BeLikeExactly "docker pull mcr.microsoft.com/windows/servercore@sha256:f5c0a8d225a4b7556db2b26753a7f4c4de3b090c1a8852983885b80694ca9840"
+        It 'pulls public docker image by image name, with both tag and digest; and fails' {
+            $theCode = {
+                Invoke-DockerPull -Image 'mcr.microsoft.com/windows/servercore' -Tag 'ltsc2019' -Digest 'sha256:f5c0a8d225a4b7556db2b26753a7f4c4de3b090c1a8852983885b80694ca9840'
+            }
+            $theCode | Should -Throw -ExceptionType ([System.Management.Automation.ParameterBindingException]) -PassThru
+        }
+
+        It 'pulls public docker image by tag only; and fails' {
+            $theCode = {
+                Invoke-DockerPull -Tag 'mcr.microsoft.com/windows/servercore' -Passthrough
+            }
+            $theCode | Should -Throw -ExceptionType ([System.Management.Automation.ParameterBindingException]) -PassThru
+        }
+
+        It 'pulls public docker image by digest only; and fails' {
+            $theCode = {
+                Invoke-DockerPull -Digest 'sha256:f5c0a8d225a4b7556db2b26753a7f4c4de3b090c1a8852983885b80694ca9840' -Passthrough
+            }
+            $theCode | Should -Throw -ExceptionType ([System.Management.Automation.ParameterBindingException]) -PassThru
+        }
+
+        It 'pulls public docker image by registry and digest only; and fails' {
+            $theCode = {
+                Invoke-DockerPull -Registry 'lalaland' -Digest 'sha256:f5c0a8d225a4b7556db2b26753a7f4c4de3b090c1a8852983885b80694ca9840' -Passthrough
+            }
+            $theCode | Should -Throw -ExceptionType ([System.Management.Automation.ParameterBindingException]) -PassThru
         }
     }
 }

--- a/Tests/Invoke-DockerPull.Tests.ps1
+++ b/Tests/Invoke-DockerPull.Tests.ps1
@@ -25,19 +25,17 @@ Describe 'Pull docker images' {
     Context 'Docker pulls docker images' {
 
         It 'pulls public docker image by image name only' {
-            # This test will most likely fail IRL because there isn't any latest tag available for this image
-            Invoke-DockerPull -Image 'mcr.microsoft.com/windows/servercore'
+            Invoke-DockerPull -Image 'mcr.microsoft.com/windows/servercore/iis'
             $result = GetMockValue -Key "pull"
             Write-Debug $result
-            $result | Should -BeLikeExactly "docker pull mcr.microsoft.com/windows/servercore:latest"
+            $result | Should -BeLikeExactly "docker pull mcr.microsoft.com/windows/servercore/iis:latest"
         }
 
         It 'pulls public docker image by registry and image name' {
-            # This test will most likely fail IRL because there isn't any latest tag available for this image
-            Invoke-DockerPull -Registry 'mcr.microsoft.com/windows' -Image 'servercore'
+            Invoke-DockerPull -Registry 'mcr.microsoft.com/windows/servercore' -Image 'iis'
             $result = GetMockValue -Key "pull"
             Write-Debug $result
-            $result | Should -BeLikeExactly "docker pull mcr.microsoft.com/windows/servercore:latest"
+            $result | Should -BeLikeExactly "docker pull mcr.microsoft.com/windows/servercore/iis:latest"
         }
 
         It 'pulls public docker image by image name and tag' {
@@ -81,5 +79,19 @@ Describe 'Pull docker images' {
             }
             $theCode | Should -Throw -ExceptionType ([System.Management.Automation.ParameterBindingException]) -PassThru
         }
-    }
+
+        It 'pulls public docker image by image name with invalid digest, missing sha256: prefix; and fails' {
+            $theCode = {
+                Invoke-DockerPull -Image 'lalaland' -Digest 'f5c0a8d225a4b7556db2b26753a7f4c4de3b090c1a8852983885b80694ca9840' -Passthrough
+            }
+            $theCode | Should -Throw -ExceptionType ([System.Management.Automation.ParameterBindingException]) -PassThru
+        }
+
+        It 'pulls public docker image by image name with invalid digest, wrong digest length; and fails' {
+            $theCode = {
+                Invoke-DockerPull -Image 'lalaland' -Digest 'sha256:f5c0a8d225a4b7556db2b26753a7f4c4d' -Passthrough
+            }
+            $theCode | Should -Throw -ExceptionType ([System.Management.Automation.ParameterBindingException]) -PassThru
+        }
+   }
 }

--- a/Tests/Test-DockerDigest.Tests.ps1
+++ b/Tests/Test-DockerDigest.Tests.ps1
@@ -1,0 +1,29 @@
+Import-Module -Force $PSScriptRoot/../Docker.Build.psm1
+. "$PSScriptRoot\..\Private\Test-DockerDigest.ps1"
+
+Describe 'Docker digest basic validation' {
+
+    Context 'Basic prefix and length checks' {
+
+        # To get the digest of a docker image:
+        #   best: docker inspect --format='{{index .RepoDigests 0}}' $ImageName
+        #   pwsh: (docker inspect $ImageName | ConvertFrom-Json).RepoDigests
+        It 'can validate valid docker digests' {
+            $digest = 'sha256:f5c0a8d225a4b7556db2b26753a7f4c4de3b090c1a8852983885b80694ca9840'
+            $result = Test-DockerDigest -Digest $digest
+            $result | Should -Be $true
+        }
+
+        It 'can validate invalid docker digests - missing sha256: prefix' {
+            $digest = 'f5c0a8d225a4b7556db2b26753a7f4c4de3b090c1a8852983885b80694ca9840'
+            $result = Test-DockerDigest -Digest $digest
+            $result | Should -Be $false
+        }
+
+        It 'can validate invalid docker digests - wrong digest length' {
+            $digest = 'sha256:f5c0a8d225a4b7556db2b26753a7f4c4de3b0'
+            $result = Test-DockerDigest -Digest $digest
+            $result | Should -Be $false
+        }
+    }
+}

--- a/Tests/Utilities.Tests.ps1
+++ b/Tests/Utilities.Tests.ps1
@@ -38,12 +38,12 @@ Describe 'Validate various support functions for testing' {
     Context 'Various other functions' {
 
         It 'can postfix default / to a string' {
-            $postfixed = Add-RegistryPostfix -Registry 'lalaland'
+            $postfixed = Add-Postfix -Registry 'lalaland'
             $postfixed | Should -BeLikeExactly 'lalaland/'
         }
 
         It 'can postfix a string to a string' {
-            $postfixed = Add-RegistryPostfix -Registry 'lala' -Postfix 'land'
+            $postfixed = Add-Postfix -Registry 'lala' -Postfix 'land'
             $postfixed | Should -BeLikeExactly 'lalaland'
         }
     }

--- a/Tests/Utilities.Tests.ps1
+++ b/Tests/Utilities.Tests.ps1
@@ -46,26 +46,5 @@ Describe 'Validate various support functions for testing' {
             $postfixed = Add-RegistryPostfix -Registry 'lala' -Postfix 'land'
             $postfixed | Should -BeLikeExactly 'lalaland'
         }
-
-        # To get the digest of a docker image:
-        #   best: docker inspect --format='{{index .RepoDigests 0}}' $ImageName
-        #   pwsh: (docker inspect $ImageName | ConvertFrom-Json).RepoDigests
-        It 'can validate valid docker digests' {
-            $digest = 'sha256:f5c0a8d225a4b7556db2b26753a7f4c4de3b090c1a8852983885b80694ca9840'
-            $result = Test-DockerDigest -Digest $digest
-            $result | Should -Be $true
-        }
-
-        It 'can validate invalid docker digests - missing sha256: prefix' {
-            $digest = 'f5c0a8d225a4b7556db2b26753a7f4c4de3b090c1a8852983885b80694ca9840'
-            $result = Test-DockerDigest -Digest $digest
-            $result | Should -Be $false
-        }
-
-        It 'can validate invalid docker digests - wrong digest length' {
-            $digest = 'sha256:f5c0a8d225a4b7556db2b26753a7f4c4de3b0'
-            $result = Test-DockerDigest -Digest $digest
-            $result | Should -Be $false
-        }
     }
 }

--- a/Tests/Utilities.Tests.ps1
+++ b/Tests/Utilities.Tests.ps1
@@ -38,13 +38,34 @@ Describe 'Validate various support functions for testing' {
     Context 'Various other functions' {
 
         It 'can postfix default / to a string' {
-            $postfixed = Add-Postfix -Data 'lalaland'
+            $postfixed = Add-RegistryPostfix -Registry 'lalaland'
             $postfixed | Should -BeLikeExactly 'lalaland/'
         }
 
         It 'can postfix a string to a string' {
-            $postfixed = Add-Postfix -Data 'lala' -Postfix 'land'
+            $postfixed = Add-RegistryPostfix -Registry 'lala' -Postfix 'land'
             $postfixed | Should -BeLikeExactly 'lalaland'
+        }
+
+        # To get the digest of a docker image:
+        #   best: docker inspect --format='{{index .RepoDigests 0}}' $ImageName
+        #   pwsh: (docker inspect $ImageName | ConvertFrom-Json).RepoDigests
+        It 'can validate valid docker digests' {
+            $digest = 'sha256:f5c0a8d225a4b7556db2b26753a7f4c4de3b090c1a8852983885b80694ca9840'
+            $result = Test-DockerDigest -Digest $digest
+            $result | Should -Be $true
+        }
+
+        It 'can validate invalid docker digests - missing sha256: prefix' {
+            $digest = 'f5c0a8d225a4b7556db2b26753a7f4c4de3b090c1a8852983885b80694ca9840'
+            $result = Test-DockerDigest -Digest $digest
+            $result | Should -Be $false
+        }
+
+        It 'can validate invalid docker digests - wrong digest length' {
+            $digest = 'sha256:f5c0a8d225a4b7556db2b26753a7f4c4de3b0'
+            $result = Test-DockerDigest -Digest $digest
+            $result | Should -Be $false
         }
     }
 }


### PR DESCRIPTION
* Supports pulling by tag, or by digest.
* Digest is the unique sha of the image, like `sha256:<64 char hash>`
* Digest takes precedence over tag if both parameters are used at the same time.