### PR TITLE
Code coverage

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -67,7 +67,7 @@ Task PublishImpl -depends Test -requiredVariables PublishDir {
 
 Task Test -depends Build {
     Import-Module Pester
-    $testResult = Invoke-Pester $PSScriptRoot/Tests -PassThru
+    $testResult = Invoke-Pester $PSScriptRoot/Tests -CodeCoverage @("Public/*.ps1","Private/*.ps1") -PassThru
 
     if ($TestResult.FailedCount -gt 0) {
         $TestResult | Format-List

--- a/Install-Prerequisites.ps1
+++ b/Install-Prerequisites.ps1
@@ -1,4 +1,5 @@
 # The psake module is needed to run tests and publish the module to powershell gallery.
 Set-PSRepository -Name "PSGallery" -InstallationPolicy Trusted
-Install-Module -Name psake -RequiredVersion 4.8.0 -Repository "PSGallery"
-Install-Module -Name pester -RequiredVersion 4.9.0 -Repository "PSGallery"
+Install-Module -Name psake -MinimumVersion 4.9.0 -Repository "PSGallery"
+Install-Module -Name pester -MinimumVersion 4.9.0 -Repository "PSGallery"
+Install-Module -Name coveralls -MinimumVersion 1.0.25 -Repository "PSGallery"


### PR DESCRIPTION
We should use the latest compatible version of our dependencies. This PR changes our approach to use minimum versions and bumps to the latest version available as of today.