### PR TITLE
Add test feature

### DIFF
--- a/Public/Invoke-PesterTests.ps1
+++ b/Public/Invoke-PesterTests.ps1
@@ -1,0 +1,19 @@
+function Invoke-PesterTests {
+    [CmdletBinding()]
+    param (
+        [ValidateRange("NonNegative ")]
+        [Int32]
+        $Depth = 0,
+        [ValidateNotNullOrEmpty()]
+        [String]
+        $TestDirectory = '.'
+    )
+    $testDirectoryPath = Format-AsAbsolutePath (Add-PostFix  $TestDirectory)
+    $testDirectoryExists = [System.IO.Directory]::Exists($testDirectoryPath)
+    if (!$testDirectoryExists) {
+        $mesage = "No such directory: ${testDirectoryPath}"
+        throw [System.IO.DirectoryNotFoundException]::new($mesage)
+    }
+    $files = Get-ChildItem -Path "${testDirectoryPath}*.Tests.ps1" -Depth $Depth
+    Invoke-Pester -Path $files -PassThru
+}

--- a/Public/Invoke-PesterTests.ps1
+++ b/Public/Invoke-PesterTests.ps1
@@ -1,9 +1,10 @@
 function Invoke-PesterTests {
     [CmdletBinding()]
     param (
-        [ValidateRange("NonNegative ")]
+        [ValidateRange("NonNegative")]
         [Int32]
         $Depth = 0,
+
         [ValidateNotNullOrEmpty()]
         [String]
         $TestDirectory = '.'

--- a/Test-Data/PesterTests/AtLevel0.Tests.ps1
+++ b/Test-Data/PesterTests/AtLevel0.Tests.ps1
@@ -1,0 +1,6 @@
+Describe 'At level 0' {
+
+    It 'is true' {
+        $true | Should -Be $true
+    }
+}

--- a/Test-Data/PesterTests/Level1/AtLevel1.Tests.ps1
+++ b/Test-Data/PesterTests/Level1/AtLevel1.Tests.ps1
@@ -1,0 +1,6 @@
+Describe 'At level 1' {
+
+    It 'is true' {
+        $true | Should -Be $true
+    }
+}

--- a/Tests/Invoke-DockerPull.Tests.ps1
+++ b/Tests/Invoke-DockerPull.Tests.ps1
@@ -1,4 +1,4 @@
-Import-Module $PSScriptRoot/../Docker.Build.psm1
+Import-Module -Force $PSScriptRoot/../Docker.Build.psm1
 Import-Module -Global -Force $PSScriptRoot/MockReg.psm1
 . "$PSScriptRoot\..\Private\Invoke-Command.ps1"
 

--- a/Tests/Invoke-DockerTag.Tests.ps1
+++ b/Tests/Invoke-DockerTag.Tests.ps1
@@ -1,4 +1,4 @@
-Import-Module $PSScriptRoot/../Docker.Build.psm1
+Import-Module -Force $PSScriptRoot/../Docker.Build.psm1
 Import-Module -Global -Force $PSScriptRoot/MockReg.psm1
 . "$PSScriptRoot\..\Private\Invoke-Command.ps1"
 

--- a/Tests/Invoke-PesterTests.Tests.ps1
+++ b/Tests/Invoke-PesterTests.Tests.ps1
@@ -1,0 +1,39 @@
+Import-Module -Force $PSScriptRoot/../Docker.Build.psm1
+
+Describe 'Run pester tests' {
+    $testData = Join-Path (Split-Path -Parent $PSScriptRoot) "Test-Data"
+    $pesterTestData = Join-Path $testData "PesterTests"
+    $dirWithNoTest = Join-Path $testData "DockerImage"
+    $dirThatDoesNotExist = Join-Path $testData "GibberishGoo"
+
+    Context 'Run with 1 pester test' {
+        It 'finds test files and produces correct command to run them' {
+            $result = Invoke-PesterTests -TestDirectory $pesterTestData
+            $result.PassedCount | Should -Be 1
+            $result.TestResult[0].Describe | Should -BeExactly 'At level 0'
+        }
+    }
+
+    Context 'Run with 2 pester tests' {
+        It 'finds test files and produces correct command to run them' {
+            $result = Invoke-PesterTests -TestDirectory $pesterTestData -Depth 1
+            $result.PassedCount | Should -Be 2
+            $result.TestResult[0].Describe | Should -BeExactly 'At level 1'
+            $result.TestResult[1].Describe | Should -BeExactly 'At level 0'
+        }
+    }
+
+    Context 'Run with 0 pester tests' {
+        It 'finds test files and produces correct command to run them' {
+            $result = Invoke-PesterTests -TestDirectory $dirWithNoTest -Depth 1
+            $result.PassedCount | Should -Be 0
+        }
+    }
+
+    Context 'Run with dir that does not exist' {
+        It 'finds test files and produces correct command to run them' {
+            $code = {Invoke-PesterTests -TestDirectory $dirThatDoesNotExist}
+            $code | Should -Throw -ExceptionType ([System.IO.DirectoryNotFoundException]) -PassThru
+        }
+    }
+}


### PR DESCRIPTION
Runs pester tests that reside with the docker image being constructed.

By default, only the tests that reside at the top directory will be run. 
This is to account for the scenario where you are traversing a directory structure of repositories that all build using this module. In this scenario we would risk executing tests for docker images below the one we we currently building if we do not limit the recursion when we find the files that pester will execute.
