### PR TITLE
Feature/pass thru

### DIFF
--- a/Source/Private/CommandResult.ps1
+++ b/Source/Private/CommandResult.ps1
@@ -2,5 +2,5 @@ class CommandResult {
     [String] $Command
     [bool] $Success
     [int] $ExitCode
-    [String] $Output
+    [String[]] $Output
 }

--- a/Source/Private/Find-LintRemarks.ps1
+++ b/Source/Private/Find-LintRemarks.ps1
@@ -1,20 +1,20 @@
 function Find-LintRemarks {
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)]
         [AllowEmptyString()]
-        [string]
-        $Text
+        [string[]]
+        $LintLines
     )
+    if ($null -eq $LintLines) {
+        return @()
+    }
+
     $lineNumber = "\B\/dev\/stdin:\d+\b"
     $lintRule = "\w{2}\d{4}"
     $lintRemark = ".*)"
-    $splitExpression = "(.+?(?=\/dev\/stdin:\d+?))"
-    $lines = ($Text -split $splitExpression | Where-Object { $_ })
     $pattern = "^(?<linenumbergroup>${lineNumber}) (?<lintrule>${lintRule}) (?<lintremark>${lintRemark}"
-
     [LintRemark[]] $lintRemarks = @()
-    $lines | Select-String -Pattern $pattern | ForEach-Object {
+    $LintLines | Select-String -Pattern $pattern | ForEach-Object {
         $lineNumber, $lintRule, $lintRemark = $_.Matches[0].Groups['linenumbergroup', 'lintrule', 'lintremark'].Value
 
         $remark = [LintRemark] @{

--- a/Source/Public/Find-ImageName.ps1
+++ b/Source/Public/Find-ImageName.ps1
@@ -7,13 +7,12 @@ function Find-ImageName {
     )
     $gitConfigPath = Join-Path "$RepositoryPath" ".git" "config"
     $gitConfigExists = $(Test-Path $gitConfigPath)
-    if (!$gitConfigExists)
-    {
+    if (!$gitConfigExists) {
         throw "No such git config: $gitConfigExists"
     }
     $commandResult = Invoke-Command "git config --file `"$gitConfigPath`" --get remote.origin.url"
     Assert-ExitCodeOK $commandResult
-    $imageName = (Find-RepositoryName -RepositoryPath $commandResult.Output).ToLower()
+    $imageName = (Find-RepositoryName -RepositoryPath $commandResult.Output[0]).ToLower()
     $result = [PSCustomObject]@{
         'ImageName' = $imageName
     }

--- a/Source/Public/Invoke-DockerBuild.ps1
+++ b/Source/Public/Invoke-DockerBuild.ps1
@@ -34,5 +34,10 @@ function Invoke-DockerBuild {
         'Tag'           = $Tag;
         "CommandResult" = $commandResult
     }
+    if ($PassThru) {
+        foreach ($line in $($commandResult.Output)) {
+            Write-Information $line
+        }
+    }
     return $result
 }

--- a/Test-Source/Integration.Tests.ps1
+++ b/Test-Source/Integration.Tests.ps1
@@ -45,6 +45,13 @@ Describe 'Use cases for this module' {
             Set-Location $script:backupLocation
         }
 
+        It 'can build an image and tag it' {
+            Invoke-DockerBuild . -ImageName 'integration-testcase-1'
+            $findImageCommand = 'docker images integration-testcase-1'
+            $result = Invoke-Command $findImageCommand
+            ([regex]::Matches($result.Output, "integration-testcase-1" )).Count | Should -BeExactly 1
+        }
+
         It "Use case #1: Can derive docker image name and tag in one go" {
             $result = Find-ImageName $dockerImageDir
             $result = Format-DockerTag | Invoke-DockerBuild -ImageName $result.ImageName


### PR DESCRIPTION
* Rework CommandResult to support multiple lines of output.
* Retrofit functions that rely on CommandResult support multi-line output.
* Support Pass-Thru for CmlLets where it makes sense.