### PR TITLE
Build/alfred notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,24 @@
 language: csharp
 dotnet: 3.0
 mono: none
+
 git:
   depth: false
+
 cache:
   directories:
     - "/home/travis/.dotnet/tools"
     - "/home/travis/.local/share/powershell/Modules"
+
 if: |
   repo != 3shapeAS/dockerbuild-pwsh OR \
   type = pull_request OR \
   branch = master OR \
   tag IS present
+
 services:
   - docker
+
 dist: bionic
 addons:
   apt:
@@ -25,6 +30,7 @@ addons:
         key_url: https://packages.microsoft.com/keys/microsoft.asc
     packages:
       - powershell
+
 install:
   - cd $TRAVIS_BUILD_DIR
   - export PATH="$PATH:$HOME/.dotnet/tools"
@@ -34,8 +40,10 @@ install:
     PreReleaseTagWithDash)
   - 'echo "GitVersion says version is : ${GitVersion_Version}"'
   - 'echo "GitVersion says prerelease tag is: ${GitVersion_PreReleaseTagWithDash}"'
+
 script:
   - pwsh -f "./Invoke-Tests.ps1"
+
 deploy:
   skip_cleanup: true
   provider: script
@@ -43,8 +51,11 @@ deploy:
   on:
     tags: true
     branch: master
-notifications:
-  slack:
-    secure: QtY+ytuHg04v68q5kQ891r4UGAFKYyHu4gCbVfmMXpYlU4OR5XiHxnUG3bPdmI3my18gg56PrdXw/54UEzc0sh2GUKMhnTVvL3h59FuvqQ+EJToWUv8Pl9whZj/4YJIMPPetfD5Dp4pz5EqiZBHgho7vyM3aqMUqZGlwy8xaqYNqjh3R5DB1wrrsoNMqgmgeebMfMh9S1f5fKVW39lt9bhrzB14idMJADUC35vT6Gis+5egMQMBZo11A4/65Hy9xbnK7GbiedLmG3uZtGKyW9Qt7EyDJFFIiV9eoMeAkivS4EiAxuu+3bFL3lOUCojqDwTVKEnJHODGhLMve2JXTjCBtdc9qI3DunuY51O5TFWrJSE5673WThftWJDejwDwNmtCsqmC++IPOoJA7+Qmf5LGJLiWXFHsSV/YEQmwYDT73EXNKLQJBmpkitOOBme5zUJBRfP9eOhW8ydHJQ8SB+E4WD/+Jag/2ceSxK8Oo3bMwkl4e4i3xbsgiTFMRGotaapjiJNxDsWDl0x2NLNe4GQgBoketGKDAsj6NDMC3nLLISxWbj2Bi2iV8n3cSHQbkbz35WX82r4khCZ+NPx+/8cGsh8S4dmLps0OaFnCHFhUWkh2OJAQGRJeeAWyFOBs1UzeOr01qXF+BrCoAORlQyZwkXTQ4ZS5Oc6n+54XU/aU=
+  provider: script
+  script: pwsh -f "./Notify-Slack.ps1"
+  on:
+    tags: true
+    branch: master
+
 after_success:
   - bash <(curl -s https://codecov.io/bash) -f coverage.json

--- a/Notify-Slack.ps1
+++ b/Notify-Slack.ps1
@@ -1,0 +1,10 @@
+$token = $Env:SlackToken
+$slackURI = "${Env:SlackURI}=${token}"
+$version = "${Env:GitVersion_Version}${Env:GitVersion_PreReleaseTagWithDash}"
+$slackChannel = 'batcave'
+$author = $(git log -1 $TRAVIS_COMMIT --pretty="%aN")
+$slackMessage = "${author} released Docker.Build-${version}`n`n" + `
+    "The new version is available from https://www.powershellgallery.com/packages/Docker.Build/${version}"
+
+$body = @{ "text" = $slackMessage; "channel" = $slackChannel; }
+Invoke-WebRequest -Uri $slackURI -Body $body -Method POST


### PR DESCRIPTION
Added a travis script provider. The script provider sends messages to slack in batcave, so we can be notified when there's a release.