### PR TITLE
Clean up redundant script blocks to use global ones

### DIFF
--- a/Test-Source/Docker.Build.Tests.psm1
+++ b/Test-Source/Docker.Build.Tests.psm1
@@ -36,7 +36,6 @@ Set-GlobalVar -Variable CodeThatReturnsExitCodeZero -Value {
     return $result
 }
 
-
 Set-GlobalVar -Variable CodeThatReturnsExitCodeOne -Value {
     StoreMockValue -Key "command" -Value $Command
     $result = [CommandResult]::new()

--- a/Test-Source/Docker.Build.Tests.psm1
+++ b/Test-Source/Docker.Build.Tests.psm1
@@ -35,3 +35,10 @@ Set-GlobalVar -Variable CodeThatReturnsExitCodeZero -Value ( {
         $result.ExitCode = 0
         return $result
     })
+
+Set-GlobalVar -Variable CodeThatReturnsExitCodeOne -Value ( {
+        StoreMockValue -Key "command" -Value $Command
+        $result = [CommandResult]::new()
+        $result.ExitCode = 1
+        return $result
+    })

--- a/Test-Source/Docker.Build.Tests.psm1
+++ b/Test-Source/Docker.Build.Tests.psm1
@@ -28,17 +28,18 @@ Set-GlobalVar -Variable LocalDockerRegistry -Value 'localhost:5000'
 Set-GlobalVar -Variable LocalDockerRegistryName -Value 'registry'
 
 # Global scriptblocks
-Set-GlobalVar -Variable CodeThatReturnsExitCodeZero -Value ( {
-        StoreMockValue -Key "command" -Value $Command
-        $result = [CommandResult]::new()
-        $result.Output = @("Hello", "World")
-        $result.ExitCode = 0
-        return $result
-    })
+Set-GlobalVar -Variable CodeThatReturnsExitCodeZero -Value {
+    StoreMockValue -Key "command" -Value $Command
+    $result = [CommandResult]::new()
+    $result.Output = @("Hello", "World")
+    $result.ExitCode = 0
+    return $result
+}
 
-Set-GlobalVar -Variable CodeThatReturnsExitCodeOne -Value ( {
-        StoreMockValue -Key "command" -Value $Command
-        $result = [CommandResult]::new()
-        $result.ExitCode = 1
-        return $result
-    })
+
+Set-GlobalVar -Variable CodeThatReturnsExitCodeOne -Value {
+    StoreMockValue -Key "command" -Value $Command
+    $result = [CommandResult]::new()
+    $result.ExitCode = 1
+    return $result
+}

--- a/Test-Source/Invoke-DockerBuild.Tests.ps1
+++ b/Test-Source/Invoke-DockerBuild.Tests.ps1
@@ -32,14 +32,7 @@ Describe 'Build docker images' {
         }
 
         It 'Throws exception if exitcode is not 0' {
-            $returnExitCodeOne = {
-                Write-Debug $Command
-                StoreMockValue -Key "command" -Value $Command
-                $result = [CommandResult]::new()
-                $result.ExitCode = 1
-                return $result
-            }
-            Mock -CommandName "Invoke-Command" $returnExitCodeOne -Verifiable -ModuleName $Global:ModuleName
+            Mock -CommandName "Invoke-Command" $Global:CodeThatReturnsExitCodeOne -Verifiable -ModuleName $Global:ModuleName
             $runner = {
                 Invoke-DockerBuild -ImageName "leeandrasmus" -Context $Global:DockerImagesDir -Dockerfile $dockerFile
             }

--- a/Test-Source/Invoke-DockerLogin.Tests.ps1
+++ b/Test-Source/Invoke-DockerLogin.Tests.ps1
@@ -1,4 +1,5 @@
 Import-Module -Force $PSScriptRoot/../Source/Docker.Build.psm1
+Import-Module -Global -Force $PSScriptRoot/Docker.Build.Tests.psm1
 Import-Module -Global -Force $PSScriptRoot/MockReg.psm1
 
 . "$PSScriptRoot\..\Source\Private\CommandResult.ps1"
@@ -7,21 +8,14 @@ Describe 'Docker login ' {
 
     BeforeEach {
         Initialize-MockReg
-        $returnsExitCodeZero = {
-            Write-Debug $Command
-            StoreMockValue -Key "Invoke-Command" -Value $Command
-            $result = [CommandResult]::new()
-            $result.ExitCode = 0
-            return $result
-        }
-        Mock -CommandName "Invoke-Command" $returnsExitCodeZero -Verifiable -ModuleName $Global:ModuleName
+        Mock -CommandName "Invoke-Command" $Global:CodeThatReturnsExitCodeZero -Verifiable -ModuleName $Global:ModuleName
     }
 
     Context 'Login to default docker registry' {
 
         It 'produced the correct command to invoke' {
             Invoke-DockerLogin -Username "Mocked" -Password (ConvertTo-SecureString 'MockedPassword' –asplaintext –force)
-            $result = GetMockValue -Key 'Invoke-Command'
+            $result = GetMockValue -Key 'command'
             $result | Should -BeLikeExactly 'Write-Output "MockedPassword" | docker login --username "Mocked" --password-stdin'
         }
     }
@@ -30,13 +24,13 @@ Describe 'Docker login ' {
 
         It 'produced the correct command to invoke' {
             Invoke-DockerLogin -Registry 'my.docker.registry' -Username "Mocked" -Password (ConvertTo-SecureString 'MockedPassword' –asplaintext –force)
-            $result = GetMockValue -Key 'Invoke-Command'
+            $result = GetMockValue -Key 'command'
             $result | Should -BeLikeExactly 'Write-Output "MockedPassword" | docker login --username "Mocked" --password-stdin my.docker.registry'
         }
 
         It 'produced the correct command to invoke, with $null registry parameter' {
             Invoke-DockerLogin -Registry $null -Username "Mocked" -Password (ConvertTo-SecureString 'MockedPassword' –asplaintext –force)
-            $result = GetMockValue -Key 'Invoke-Command'
+            $result = GetMockValue -Key 'command'
             $result | Should -BeLikeExactly 'Write-Output "MockedPassword" | docker login --username "Mocked" --password-stdin'
         }
     }

--- a/Test-Source/Invoke-DockerPush.Tests.ps1
+++ b/Test-Source/Invoke-DockerPush.Tests.ps1
@@ -10,13 +10,7 @@ Describe 'docker push' {
 
         BeforeEach {
             Initialize-MockReg
-            $returnExitCodeZero = {
-                StoreMockValue -Key "Invoke-Command" -Value $Command
-                $result = [CommandResult]::new()
-                $result.ExitCode = 0
-                return $result
-            }
-            Mock -CommandName "Invoke-Command" $returnExitCodeZero -Verifiable -ModuleName $Global:ModuleName
+            Mock -CommandName 'Invoke-Command' $Global:CodeThatReturnsExitCodeZero -Verifiable -ModuleName $Global:ModuleName
         }
 
         AfterEach {
@@ -26,38 +20,33 @@ Describe 'docker push' {
         It 'produces the correct command to invoke with only image name provided' {
             Invoke-DockerPush -ImageName 'cool-image'
 
-            $mockResult = GetMockValue -Key 'Invoke-Command'
+            $mockResult = GetMockValue -Key 'command'
             $mockResult | Should -Be "docker push cool-image:latest"
         }
 
         It 'produces the correct command to invoke with image name and registry provided' {
             Invoke-DockerPush -ImageName 'cool-image' -Registry 'hub.docker.com:1337/thebestdockerimages'
 
-            $mockResult = GetMockValue -Key 'Invoke-Command'
+            $mockResult = GetMockValue -Key 'command'
             $mockResult | Should -Be "docker push hub.docker.com:1337/thebestdockerimages/cool-image:latest"
         }
 
         It 'produces the correct command to invoke with image name and $null registry value provided' {
             Invoke-DockerPush -ImageName 'cool-image' -Registry $null
 
-            $mockResult = GetMockValue -Key 'Invoke-Command'
+            $mockResult = GetMockValue -Key 'command'
             $mockResult | Should -Be "docker push cool-image:latest"
         }
 
         It 'produces the correct command to invoke with image name, registry and tag provided' {
             Invoke-DockerPush -ImageName 'cool-image' -Registry 'hub.docker.com:1337/thebestdockerimages' -Tag 'v1.0.3'
 
-            $mockResult = GetMockValue -Key 'Invoke-Command'
+            $mockResult = GetMockValue -Key 'command'
             $mockResult | Should -Be "docker push hub.docker.com:1337/thebestdockerimages/cool-image:v1.0.3"
         }
 
         It 'throws an exception if the execution of docker push did not succeed' {
-            $errorProducingCode = {
-                $result = [CommandResult]::new()
-                $result.ExitCode = 1
-                return $result
-            }
-            Mock -CommandName "Invoke-Command" $errorProducingCode -Verifiable -ModuleName $Global:ModuleName
+            Mock -CommandName 'Invoke-Command' $Global:CodeThatReturnsExitCodeOne -Verifiable -ModuleName $Global:ModuleName
 
             $theCode = {
                 Invoke-DockerPush -ImageName 'cool-image' -Registry 'hub.docker.com:1337/thebestdockerimages' -Tag 'v1.0.3'
@@ -80,13 +69,7 @@ Describe 'docker push' {
 
         BeforeEach {
             Initialize-MockReg
-            $returnExitCodeZero = {
-                StoreMockValue -Key "Invoke-Command" -Value $Command
-                $result = [CommandResult]::new()
-                $result.ExitCode = 0
-                return $result
-            }
-            Mock -CommandName "Invoke-Command" $returnExitCodeZero -Verifiable -ModuleName $Global:ModuleName
+            Mock -CommandName 'Invoke-Command' $Global:CodeThatReturnsExitCodeZero -Verifiable -ModuleName $Global:ModuleName
         }
 
         AfterEach {
@@ -110,7 +93,7 @@ Describe 'docker push' {
 
         it 'can redirect output' {
             $tempFile = New-TemporaryFile
-            Mock -CommandName "Invoke-Command" $Global:CodeThatReturnsExitCodeZero -Verifiable -ModuleName $Global:ModuleName
+            Mock -CommandName 'Invoke-Command' $Global:CodeThatReturnsExitCodeZero -Verifiable -ModuleName $Global:ModuleName
 
             Invoke-DockerPush -ImageName 'cool-image' -Passthru 6> $tempFile
 


### PR DESCRIPTION
Clean up the rest of the exit code 0/1 script blocks used by tests, to use the global ones.