### PR TITLE
Security fix/mask password

### DIFF
--- a/Source/Public/Invoke-DockerLogin.ps1
+++ b/Source/Public/Invoke-DockerLogin.ps1
@@ -27,8 +27,7 @@ function Invoke-DockerLogin {
         Write-PassThruOuput $($commandResult.Output)
     }
     # Mask password from being shown
-    $maskedCommandResult = $commandResult
-    $maskedCommandResult.Command = $maskedCommand
-    Assert-ExitCodeOK $maskedCommandResult
+    $commandResult.Command = $maskedCommand
+    Assert-ExitCodeOK $commandResult
     return $commandResult
 }

--- a/Source/Public/Invoke-DockerLogin.ps1
+++ b/Source/Public/Invoke-DockerLogin.ps1
@@ -20,11 +20,15 @@ function Invoke-DockerLogin {
     )
     [String] $plaintextPassword = [System.Net.NetworkCredential]::new("", $Password).Password
     $command = "Write-Output `"${plainTextPassword}`" | docker login --username `"${Username}`" --password-stdin ${Registry}".TrimEnd()
-    Write-Debug ($command.Replace($plaintextPassword, "*********"))
+    $maskedCommand = $command.Replace($plaintextPassword, "*********")
+    Write-Debug ($maskedCommand)
     [CommandResult] $commandResult = Invoke-Command $command
     if ($PassThru) {
         Write-PassThruOuput $($commandResult.Output)
     }
-    Assert-ExitCodeOK $commandResult
+    # Mask password from being shown
+    $maskedCommandResult = $commandResult
+    $maskedCommandResult.Command = $maskedCommand
+    Assert-ExitCodeOK $maskedCommandResult
     return $commandResult
 }

--- a/Test-Source/Invoke-DockerLogin.Tests.ps1
+++ b/Test-Source/Invoke-DockerLogin.Tests.ps1
@@ -10,61 +10,65 @@ Describe 'Login failure' {
 
         BeforeEach {
             Initialize-MockReg
-            $amok = { # Do not throw exception }
-                Mock -CommandName "Invoke-Command" $Global:CodeThatReturnsExitCodeOne -Verifiable -ModuleName $Global:ModuleName
-                Mock -CommandName "Assert-ExitCodeOK" $amok -Verifiable -ModuleName $Global:ModuleName
+            $assertExitCodeOkMocked = {
+                # Capture the masked command
+                StoreMockValue -Key "maskedCommand" -Value $Result.Command
+                throw [System.Exception]::new()
             }
+            Mock -CommandName "Invoke-Command" $Global:CodeThatReturnsExitCodeOne -Verifiable -ModuleName $Global:ModuleName
+            Mock -CommandName "Assert-ExitCodeOK" $assertExitCodeOkMocked -Verifiable -ModuleName $Global:ModuleName
+        }
 
-            it 'should mask password from the logs when login fails after thrown exception' {
-                # $loginCode = { Invoke-DockerLogin -Username "Mocked" -Password (ConvertTo-SecureString 'MockedPassword' –asplaintext –force) }
-                # $result = $loginCode | Should -BeExactly 'Write-Output "*********" | docker login --username "Mocked" --password-stdin'
-                $result = Invoke-DockerLogin -Username "Mocked" -Password (ConvertTo-SecureString 'MockedPassword' –asplaintext –force)
-                $result | Should -BeExactly 'Write-Output "*********" | docker login --username "Mocked" --password-stdin'
-            }
+        it 'should mask password from the logs when login fails after thrown exception' {
+            $loginCode = { Invoke-DockerLogin -Username "Mocked" -Password (ConvertTo-SecureString 'MockedPassword' –asplaintext –force) }
+            $loginCode | Should -Throw -ExceptionType ([System.Exception]) -PassThru
+            $result = GetMockValue -Key 'maskedCommand'
+            $result | Should -BeExactly 'Write-Output "*********" | docker login --username "Mocked" --password-stdin'
+        }
+    }
+}
+
+Describe 'Docker login ' {
+
+    BeforeEach {
+        Initialize-MockReg
+        Mock -CommandName "Invoke-Command" $Global:CodeThatReturnsExitCodeZero -Verifiable -ModuleName $Global:ModuleName
+    }
+
+    Context 'Login to default docker registry' {
+
+        It 'produced the correct command to invoke' {
+            Invoke-DockerLogin -Username "Mocked" -Password (ConvertTo-SecureString 'MockedPassword' –asplaintext –force)
+            $result = GetMockValue -Key 'command'
+            $result | Should -BeExactly 'Write-Output "MockedPassword" | docker login --username "Mocked" --password-stdin'
         }
     }
 
-    Describe 'Docker login ' {
+    Context 'Login to specific docker registry' {
 
-        BeforeEach {
-            Initialize-MockReg
+        It 'produced the correct command to invoke' {
+            Invoke-DockerLogin -Registry 'my.docker.registry' -Username "Mocked" -Password (ConvertTo-SecureString 'MockedPassword' –asplaintext –force)
+            $result = GetMockValue -Key 'command'
+            $result | Should -BeExactly 'Write-Output "MockedPassword" | docker login --username "Mocked" --password-stdin my.docker.registry'
+        }
+
+        It 'produced the correct command to invoke, with $null registry parameter' {
+            Invoke-DockerLogin -Registry $null -Username "Mocked" -Password (ConvertTo-SecureString 'MockedPassword' –asplaintext –force)
+            $result = GetMockValue -Key 'command'
+            $result | Should -BeExactly 'Write-Output "MockedPassword" | docker login --username "Mocked" --password-stdin'
+        }
+    }
+
+    Context 'Passthru execution' {
+
+        it 'can redirect output' {
+            $tempFile = New-TemporaryFile
             Mock -CommandName "Invoke-Command" $Global:CodeThatReturnsExitCodeZero -Verifiable -ModuleName $Global:ModuleName
-        }
 
-        Context 'Login to default docker registry' {
+            Invoke-DockerLogin -Username "Mocked" -Password (ConvertTo-SecureString 'MockedPassword' –asplaintext –force) -Passthru 6> $tempFile
+            $result = Get-Content $tempFile
 
-            It 'produced the correct command to invoke' {
-                Invoke-DockerLogin -Username "Mocked" -Password (ConvertTo-SecureString 'MockedPassword' –asplaintext –force)
-                $result = GetMockValue -Key 'command'
-                $result | Should -BeExactly 'Write-Output "MockedPassword" | docker login --username "Mocked" --password-stdin'
-            }
-        }
-
-        Context 'Login to specific docker registry' {
-
-            It 'produced the correct command to invoke' {
-                Invoke-DockerLogin -Registry 'my.docker.registry' -Username "Mocked" -Password (ConvertTo-SecureString 'MockedPassword' –asplaintext –force)
-                $result = GetMockValue -Key 'command'
-                $result | Should -BeExactly 'Write-Output "MockedPassword" | docker login --username "Mocked" --password-stdin my.docker.registry'
-            }
-
-            It 'produced the correct command to invoke, with $null registry parameter' {
-                Invoke-DockerLogin -Registry $null -Username "Mocked" -Password (ConvertTo-SecureString 'MockedPassword' –asplaintext –force)
-                $result = GetMockValue -Key 'command'
-                $result | Should -BeExactly 'Write-Output "MockedPassword" | docker login --username "Mocked" --password-stdin'
-            }
-        }
-
-        Context 'Passthru execution' {
-
-            it 'can redirect output' {
-                $tempFile = New-TemporaryFile
-                Mock -CommandName "Invoke-Command" $Global:CodeThatReturnsExitCodeZero -Verifiable -ModuleName $Global:ModuleName
-
-                Invoke-DockerLogin -Username "Mocked" -Password (ConvertTo-SecureString 'MockedPassword' –asplaintext –force) -Passthru 6> $tempFile
-                $result = Get-Content $tempFile
-
-                $result | Should -Be @('Hello', 'World')
-            }
+            $result | Should -Be @('Hello', 'World')
         }
     }
+}


### PR DESCRIPTION
* Password is leaked via the logs / console when docker login fails. This PR fixes it and masks the password from being leaked.
* `-BeLikeExactly` passes when the strings are not exactly the same. `-BeExactly` should be the more appropriate in these tests.

Big thanks 🙌 to @casz for helping out.