### PR TITLE
Obsolete. Covered by #60. ~Feature `Invoke-DockerBuild -CacheFrom imageName:tag` #52~

### DIFF
--- a/Source/Public/Invoke-DockerBuild.ps1
+++ b/Source/Public/Invoke-DockerBuild.ps1
@@ -26,11 +26,19 @@ function Invoke-DockerBuild {
         [String]
         $Dockerfile = "Dockerfile",
 
+        [String]
+        $CacheFrom = '',
+
         [Switch]
         $PassThru
     )
     $postfixedRegistry = Add-Postfix -Value $Registry
-    $commandResult = Invoke-Command "docker build `"${Context}`" -t ${postfixedRegistry}${ImageName}:${Tag} -f `"${Dockerfile}`""
+
+    if (![String]::IsNullOrEmpty($CacheFrom)) {
+        $cacheFromCommand = " --cache-from ${CacheFrom}"
+    }
+    $dockerBuildCommand = "docker build `"${Context}`" -t ${postfixedRegistry}${ImageName}:${Tag} -f `"${Dockerfile}`"" + $cacheFromCommand
+    $commandResult = Invoke-Command $dockerBuildCommand
     Assert-ExitCodeOK $commandResult
     $result = [PSCustomObject]@{
         'Dockerfile'    = $Dockerfile;

--- a/Test-Source/Invoke-DockerBuild.Tests.ps1
+++ b/Test-Source/Invoke-DockerBuild.Tests.ps1
@@ -44,7 +44,22 @@ Describe 'Build docker images' {
         It 'creates correct docker build command, with $null registry parameter' {
             Invoke-DockerBuild -ImageName "leeandrasmus" -Context $Global:DockerImagesDir -Dockerfile $dockerFile -Registry $null
             $result = GetMockValue -Key "command"
-            $result | Should -BeLikeExactly "docker build `"$($Global:DockerImagesDir)`" -t leeandrasmus:latest -f `"${dockerFile}`""
+            $result | Should -BeExactly "docker build `"$Global:DockerImagesDir`" -t leeandrasmus:latest -f `"${dockerFile}`""
+        }
+    }
+
+    Context 'Docker build with cache from parameter' {
+
+        It 'creates correct docker build command, with valid registry parameter and with correct CacheFrom image name' {
+            Invoke-DockerBuild -ImageName "leeandrasmus" -Context $Global:DockerImagesDir -Dockerfile $dockerFile -Registry 'valid' -CacheFrom 'leeandrasmus:sha256'
+            $result = GetMockValue -Key "command"
+            $result | Should -BeExactly "docker build `"$Global:DockerImagesDir`" -t valid/leeandrasmus:latest -f `"${dockerFile}`" --cache-from leeandrasmus:sha256"
+        }
+
+        It 'creates correct docker build command, with $null registry parameter and with correct CacheFrom image name' {
+            Invoke-DockerBuild -ImageName "leeandrasmus" -Context $Global:DockerImagesDir -Dockerfile $dockerFile -Registry $null -CacheFrom 'leeandrasmus:notlatest'
+            $result = GetMockValue -Key "command"
+            $result | Should -BeExactly "docker build `"$Global:DockerImagesDir`" -t leeandrasmus:latest -f `"${dockerFile}`" --cache-from leeandrasmus:notlatest"
         }
     }
 

--- a/Test-Source/Invoke-DockerBuild.Tests.ps1
+++ b/Test-Source/Invoke-DockerBuild.Tests.ps1
@@ -3,19 +3,12 @@ Import-Module -Global -Force $PSScriptRoot/Docker.Build.Tests.psm1
 Import-Module -Global -Force $PSScriptRoot/MockReg.psm1
 
 . "$PSScriptRoot\..\Source\Private\Invoke-Command.ps1"
-. "$PSScriptRoot\..\Source\Private\CommandResult.ps1"
-. "$PSScriptRoot\..\Source\Private\Assert-ExitCodeOk.ps1"
 
 Describe 'Build docker images' {
 
     BeforeEach {
         Initialize-MockReg
-        if ($IsWindows) {
-            $dockerFile = Join-Path $Global:DockerImagesDir "Windows.Dockerfile"
-        }
-        elseif ($IsLinux) {
-            $dockerFile = Join-Path $Global:DockerImagesDir "Linux.Dockerfile"
-        }
+        $dockerFile = Join-Path $Global:DockerImagesDir "Linux.Dockerfile"
         Mock -CommandName "Invoke-Command" $Global:CodeThatReturnsExitCodeZero -Verifiable -ModuleName $Global:ModuleName
     }
 

--- a/Test-Source/Invoke-DockerBuild.Tests.ps1
+++ b/Test-Source/Invoke-DockerBuild.Tests.ps1
@@ -21,24 +21,22 @@ Describe 'Build docker images' {
         It 'creates correct docker build command' {
             Invoke-DockerBuild -ImageName "leeandrasmus" -Context $Global:DockerImagesDir -Dockerfile $dockerFile
             $result = GetMockValue -Key "command"
-            $result | Should -BeLikeExactly "docker build `"$($Global:DockerImagesDir)`" -t leeandrasmus:latest -f `"${dockerFile}`""
+            $result | Should -BeExactly "docker build `"$Global:DockerImagesDir`" -t leeandrasmus:latest -f `"${dockerFile}`""
         }
 
         It 'Throws exception if exitcode is not 0' {
             Mock -CommandName "Invoke-Command" $Global:CodeThatReturnsExitCodeOne -Verifiable -ModuleName $Global:ModuleName
-            $runner = {
-                Invoke-DockerBuild -ImageName "leeandrasmus" -Context $Global:DockerImagesDir -Dockerfile $dockerFile
-            }
+            $runner = { Invoke-DockerBuild -ImageName "leeandrasmus" -Context $Global:DockerImagesDir -Dockerfile $dockerFile }
             $runner | Should -Throw -ExceptionType ([System.Exception]) -PassThru
         }
     }
 
-    Context 'Docker build with various parameters' {
+    Context 'Docker build with various registry parameters' {
 
         It 'creates correct docker build command, with valid registry parameter' {
             Invoke-DockerBuild -ImageName "leeandrasmus" -Context $Global:DockerImagesDir -Dockerfile $dockerFile -Registry 'valid'
             $result = GetMockValue -Key "command"
-            $result | Should -BeLikeExactly "docker build `"$($Global:DockerImagesDir)`" -t valid/leeandrasmus:latest -f `"${dockerFile}`""
+            $result | Should -BeExactly "docker build `"$Global:DockerImagesDir`" -t valid/leeandrasmus:latest -f `"${dockerFile}`""
         }
 
         It 'creates correct docker build command, with $null registry parameter' {

--- a/Test-Source/Invoke-DockerTag.Tests.ps1
+++ b/Test-Source/Invoke-DockerTag.Tests.ps1
@@ -7,16 +7,8 @@ Import-Module -Global -Force $PSScriptRoot/MockReg.psm1
 Describe 'Tag docker images' {
 
     BeforeEach {
-        $returnExitCodeZero = {
-            Write-Debug $Command
-            StoreMockValue -Key "mock" -Value $Command
-            $result = [PSCustomObject]@{
-                ExitCode = 0
-            }
-            return $result
-        }
         Initialize-MockReg
-        Mock -CommandName "Invoke-Command" $returnExitCodeZero -Verifiable -ModuleName $Global:ModuleName
+        Mock -CommandName "Invoke-Command" $Global:CodeThatReturnsExitCodeZero -Verifiable -ModuleName $Global:ModuleName
     }
 
     AfterEach {
@@ -27,28 +19,28 @@ Describe 'Tag docker images' {
 
         It 'tags image by image name with image name' {
             Invoke-DockerTag -ImageName 'oldname' -NewImageName 'newimage'
-            $result = GetMockValue -Key "mock"
+            $result = GetMockValue -Key "command"
             Write-Debug $result
             $result | Should -BeLikeExactly "docker tag oldname:latest newimage:latest"
         }
 
         It 'tags image by image name and tag with new image name and tag' {
             Invoke-DockerTag -ImageName 'oldname' -Tag 'pester' -NewImageName 'newimage' -NewTag 'pester'
-            $result = GetMockValue -Key "mock"
+            $result = GetMockValue -Key "command"
             Write-Debug $result
             $result | Should -BeLikeExactly "docker tag oldname:pester newimage:pester"
         }
 
         It 'tags image by image name and tag, with new image name' {
             Invoke-DockerTag -ImageName 'oldname' -Tag 'source' -NewImageName 'newimage'
-            $result = GetMockValue -Key "mock"
+            $result = GetMockValue -Key "command"
             Write-Debug $result
             $result | Should -BeLikeExactly "docker tag oldname:source newimage:latest"
         }
 
         It 'tags image by image name with new image name and tag' {
             Invoke-DockerTag -ImageName 'oldname' -NewImageName 'newimage' -NewTag 'target'
-            $result = GetMockValue -Key "mock"
+            $result = GetMockValue -Key "command"
             Write-Debug $result
             $result | Should -BeLikeExactly "docker tag oldname:latest newimage:target"
         }
@@ -58,77 +50,77 @@ Describe 'Tag docker images' {
 
         It 'tags private image as public image with image name only' {
             Invoke-DockerTag -Registry 'artifactoryfqdn' -ImageName 'oldname' -NewImageName 'newimage'
-            $result = GetMockValue -Key "mock"
+            $result = GetMockValue -Key "command"
             Write-Debug $result
             $result | Should -BeLikeExactly "docker tag artifactoryfqdn/oldname:latest newimage:latest"
         }
 
         It 'tags private image as public image with image name and $null registry value' {
             Invoke-DockerTag -Registry 'artifactoryfqdn' -ImageName 'oldname' -NewImageName 'newimage' -NewRegistry $null
-            $result = GetMockValue -Key "mock"
+            $result = GetMockValue -Key "command"
             Write-Debug $result
             $result | Should -BeLikeExactly "docker tag artifactoryfqdn/oldname:latest newimage:latest"
         }
 
         It 'tags private docker image as public docker image with image name and tag' {
             Invoke-DockerTag -Registry 'artifactoryfqdn' -ImageName 'oldname' -NewImageName 'newimage' -NewTag 'newtag'
-            $result = GetMockValue -Key "mock"
+            $result = GetMockValue -Key "command"
             Write-Debug $result
             $result | Should -BeLikeExactly "docker tag artifactoryfqdn/oldname:latest newimage:newtag"
         }
 
         It 'tags private docker image with tag as public docker image with image name only' {
             Invoke-DockerTag -Registry 'artifactoryfqdn' -ImageName 'oldname' -Tag 'nomansland' -NewImageName 'newimage'
-            $result = GetMockValue -Key "mock"
+            $result = GetMockValue -Key "command"
             Write-Debug $result
             $result | Should -BeLikeExactly "docker tag artifactoryfqdn/oldname:nomansland newimage:latest"
         }
 
         It 'tags private docker image with tag as public docker image with image name and tag' {
             Invoke-DockerTag -Registry 'artifactoryfqdn' -ImageName 'oldname' -Tag 'nomansland' -NewImageName 'newimage' -NewTag 'newtag'
-            $result = GetMockValue -Key "mock"
+            $result = GetMockValue -Key "command"
             Write-Debug $result
             $result | Should -BeLikeExactly "docker tag artifactoryfqdn/oldname:nomansland newimage:newtag"
         }
 
         It 'tags private docker image with tag as public docker image with image name, tag and empty registry' {
             Invoke-DockerTag -Registry 'artifactoryfqdn' -ImageName 'oldname' -Tag 'nomansland' -NewImageName 'newimage' -NewTag 'newtag' -NewRegistry ''
-            $result = GetMockValue -Key "mock"
+            $result = GetMockValue -Key "command"
             Write-Debug $result
             $result | Should -BeLikeExactly "docker tag artifactoryfqdn/oldname:nomansland newimage:newtag"
         }
 
         It 'tags private docker image as private docker image with image name only' {
             Invoke-DockerTag -Registry 'artifactoryfqdn/docker-repo' -ImageName 'oldname' -NewRegistry 'dockerhub.com:5999' -NewImageName 'newimage'
-            $result = GetMockValue -Key "mock"
+            $result = GetMockValue -Key "command"
             Write-Debug $result
             $result | Should -BeLikeExactly "docker tag artifactoryfqdn/docker-repo/oldname:latest dockerhub.com:5999/newimage:latest"
         }
 
         It 'tags private docker image as private docker image with image name and tag' {
             Invoke-DockerTag -Registry 'artifactoryfqdn' -ImageName 'oldname' -NewRegistry 'dockerhub.com:5999/docker-repo' -NewImageName 'newimage' -NewTag 'newtag'
-            $result = GetMockValue -Key "mock"
+            $result = GetMockValue -Key "command"
             Write-Debug $result
             $result | Should -BeLikeExactly "docker tag artifactoryfqdn/oldname:latest dockerhub.com:5999/docker-repo/newimage:newtag"
         }
 
         It 'tags public docker image as private docker image with image name only' {
             Invoke-DockerTag -ImageName 'oldname' -NewRegistry 'dockerhub.com:5999/docker-repo' -NewImageName 'newimage'
-            $result = GetMockValue -Key "mock"
+            $result = GetMockValue -Key "command"
             Write-Debug $result
             $result | Should -BeLikeExactly "docker tag oldname:latest dockerhub.com:5999/docker-repo/newimage:latest"
         }
 
         It 'tags public docker image as private docker image with image name and tag' {
             Invoke-DockerTag -ImageName 'oldname' -NewRegistry 'dockerhub.com:5999' -NewImageName 'newimage' -NewTag 'newtag'
-            $result = GetMockValue -Key "mock"
+            $result = GetMockValue -Key "command"
             Write-Debug $result
             $result | Should -BeLikeExactly "docker tag oldname:latest dockerhub.com:5999/newimage:newtag"
         }
 
         It 'tags explicit public docker image as private docker image with image name and tag' {
             Invoke-DockerTag -Registry '' -ImageName 'oldname' -NewRegistry 'dockerhub.com:5999' -NewImageName 'newimage' -NewTag 'newtag'
-            $result = GetMockValue -Key "mock"
+            $result = GetMockValue -Key "command"
             Write-Debug $result
             $result | Should -BeLikeExactly "docker tag oldname:latest dockerhub.com:5999/newimage:newtag"
         }
@@ -137,15 +129,7 @@ Describe 'Tag docker images' {
     Context 'tags invalid image' {
 
         It 'tags invalid image with invalid registry' {
-            $returnExitCodeOne = {
-                Write-Debug $Command
-                StoreMockValue -Key "mock" -Value $Command
-                $result = [PSCustomObject]@{
-                    ExitCode = 1
-                }
-                return $result
-            }
-            Mock -CommandName "Invoke-Command" $returnExitCodeOne -Verifiable -ModuleName $Global:ModuleName
+            Mock -CommandName "Invoke-Command" $Global:CodeThatReturnsExitCodeOne -Verifiable -ModuleName $Global:ModuleName
             $runner = { Invoke-DockerTag -ImageName 'oldname' -NewRegistry '.' -NewImageName 'newimage' -NewTag 'newtag' }
             $runner | Should -Throw -ExceptionType ([System.Exception]) -PassThru
         }


### PR DESCRIPTION
### Superseded by #60 🤦‍♂️

* Added `-CacheFrom` parameter for `Invoke-DockerBuild` as an optional parameter.
* Added supporting positive tests.
* Did not add negative testing as the command should instead be parsed to docker cli.
* Minor cosmetic clean up.
