### PR TITLE
use the new docker image that supports linux and windows platform

### DIFF
--- a/Source/Public/Invoke-DockerTests.ps1
+++ b/Source/Public/Invoke-DockerTests.ps1
@@ -36,7 +36,7 @@ function Invoke-DockerTests {
         " -v `"${here}:/configs`"" + `
         " -v `"${absoluteTestReportDir}:/report`"" + `
         " -v /var/run/docker.sock:/var/run/docker.sock" + `
-        " rasmusjelsgaard/containerized-structure-test:latest test -i ${ImageName} --test-report /report/${TestReportName}"
+        " 3shape/containerized-structure-test:latest test -i ${ImageName} --test-report /report/${TestReportName}"
 
     $ConfigFiles.ForEach( {
             $configFile = Convert-ToUnixPath (Resolve-Path -Path $_  -Relative)


### PR DESCRIPTION
Would be nice to add appveyor in a separate PR to confirm 3shape/containerized-structure-test:latest works on windows in our powershell tests 😅 

Steps I did to make it work

Here are the dockerfiles: https://github.com/3shapeAS/containerized-structure-test

```powershell
$env:DOCKER_CLI_EXPERIMENTAL='enabled'
# Linux context
docker build -t 3shape/containerized-structure-test:latest-linux -f ./Dockerfile .
# Windows context
docker build -t 3shape/containerized-structure-test:latest-windows -f ./Dockerfile-windows .
docker manifest create 3shape/containerized-structure-test:latest 3shape/containerized-structure-test:latest-linux 3shape/containerized-structure-test:latest-windows
docker manifest push --purge 3shape/containerized-structure-test:latest
```