### PR TITLE
fix #112 - cache docker os type info in a module-internal hashtable

### DIFF
--- a/Source/Docker-CI.psm1
+++ b/Source/Docker-CI.psm1
@@ -11,4 +11,11 @@ Foreach ($import in @($Public + $Private)) {
         Write-Error -Message "Failed to import function $($import.fullname): $_"
     }
 }
+
+# This is an internal, module-wide hashtable used to cache data and objects.
+# Hashtabels are always passed by reference, so we avoid accidental scope issues.
+$script:CachedDockerInformation = @{
+    'OSType' = $null
+}
+
 Export-ModuleMember -Function $Public.Basename

--- a/Source/Private/Find-DockerOSType.ps1
+++ b/Source/Private/Find-DockerOSType.ps1
@@ -1,5 +1,10 @@
 function Find-DockerOSType {
-    $commandResult = Invoke-DockerCommand 'info --format "{{.OSType}}"'
-    Assert-ExitCodeOk $commandResult
-    return $commandResult.Output
+    if ($script:CachedDockerInformation['OSType']) {
+        return $script:CachedDockerInformation['OSType']
+    } else {
+        $commandResult = Invoke-DockerCommand 'info --format "{{.OSType}}"'
+        Assert-ExitCodeOk $commandResult
+        $script:CachedDockerInformation['OSType'] = $commandResult.Output
+        return $commandResult.Output
+    }
 }


### PR DESCRIPTION
The hashtable approach lets us cache more information in the future.
Because hashtables are also always passed by reference in PowerShell,
they avoid accidental scope bugs where a function that's been passed the
cache *thinks* it's updating it but is really only updating it's
local-scope variable. Hashtables can be passed to functions without this
concern.

---

Let me know if you prefer a different approach or require style changes etc.!

`$script:`-scope variables in a PowerShell module are "internal" to the module
and automatically accessible from all cmdlets of the module, but are not exported
to the users PowerShell session. I think this makes them ideal for implementing a simple cache.